### PR TITLE
use field tag `binary:"packed"` to encode ints value as varint/uvarint for reged structs

### DIFF
--- a/coder.go
+++ b/coder.go
@@ -50,15 +50,6 @@ func (this *coder) Skip(size int) int {
 	return -1
 }
 
-func (this *coder) Resize(size int) bool {
-	ok := len(this.buff) < size
-	if ok {
-		this.buff = make([]byte, size)
-	}
-	this.Reset()
-	return ok
-}
-
 // Reset move the read/write pointer to the beginning of buffer
 // and set all reseted bytes to 0.
 func (this *coder) Reset() {
@@ -69,6 +60,7 @@ func (this *coder) Reset() {
 	this.resetBoolCoder()
 }
 
+// reset the state of bool coder
 func (this *coder) resetBoolCoder() {
 	this.boolPos = -1
 	this.boolBit = 0

--- a/coder_test.go
+++ b/coder_test.go
@@ -974,22 +974,64 @@ func TestPackedInts(t *testing.T) {
 		F uint64   `binary:"packed"`
 		G []uint64 `binary:"packed"`
 	}
-	var ints = packedInts{1, 2, 3, 4, 5, 6, []uint64{7, 8, 9}}
+	var data = packedInts{1, 2, 3, 4, 5, 6, []uint64{7, 8, 9}}
 	RegStruct((*packedInts)(nil))
-	b, err := Encode(ints, nil)
+	b, err := Encode(data, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	var ints2 packedInts
-	err = Decode(b, &ints2)
-	if err != nil {
-		t.Error(err)
-	}
-	if s := Sizeof(ints); s != len(b) {
+	if s := Sizeof(data); s != len(b) {
 		t.Errorf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, s)
 	}
-	if !reflect.DeepEqual(ints2, ints) {
-		t.Errorf("PackedInts got %+v\nneed %+v\n", ints2, ints)
+	check := []byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
+	if !reflect.DeepEqual(b, check) {
+		t.Errorf("PackedInts %#v\n got %+v\nneed %+v\n", data, b, check)
 	}
-	//fmt.Printf("size=%d %#v\n%#v\n", Sizeof(ints), ints, b)
+
+	var dataDecode packedInts
+	err = Decode(b, &dataDecode)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(dataDecode, data) {
+		t.Errorf("PackedInts got %+v\nneed %+v\n", dataDecode, data)
+	}
+}
+
+func TestBools(t *testing.T) {
+	type boolset struct {
+		A uint8   //0x11
+		B bool    //true
+		C uint8   //0x22
+		D []bool  //[]bool{true, false, true}
+		E bool    //true
+		F *uint32 //false
+		G bool    //true
+		H uint8   //0x33
+	}
+	var data = boolset{
+		0x11, true, 0x22, []bool{true, false, true}, true, nil, true, 0x33,
+	}
+	b, err := Encode(data, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	size := Sizeof(data)
+	if size != len(b) {
+		fmt.Printf("EncodeBools got %#v %+v\nneed %+v\n", len(b), b, size)
+	}
+	check := []byte{0x11, 0xb, 0x22, 0x3, 0x5, 0x33}
+	if !reflect.DeepEqual(b, check) {
+		t.Errorf("EncodeBools %#v\n got %+v\nneed %+v\n", data, b, check)
+	}
+
+	var dataDecode boolset
+	err = Decode(b, &dataDecode)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(dataDecode, data) {
+		t.Errorf("EncodeBools got %+v\nneed %+v\n", dataDecode, data)
+	}
 }

--- a/coder_test.go
+++ b/coder_test.go
@@ -559,7 +559,7 @@ func TestByteReaderWriter(t *testing.T) {
 }
 
 func TestDecoderSkip(t *testing.T) {
-	type s struct {
+	type skipedStruct struct {
 		S         string
 		I         int
 		U         uint
@@ -568,8 +568,15 @@ func TestDecoderSkip(t *testing.T) {
 		U16Array  [5]uint16
 		StrArray  [5]string
 		Struct    struct{ A uint8 }
+		Bool1     bool
+		Pointer   *uint32
+		Bool2     bool
+		Packed1   uint32 `binary:"packed"`
+		Packed2   int64  `binary:"packed"`
 	}
-	var w [5]s
+	RegStruct((*skipedStruct)(nil))
+
+	var w [5]skipedStruct
 	for i := len(w) - 1; i >= 0; i-- {
 		w[i].S = fmt.Sprintf("%d", i)
 		w[i].I = i
@@ -578,9 +585,15 @@ func TestDecoderSkip(t *testing.T) {
 		w[i].Struct.A = uint8(i)
 		w[i].U16Array[i] = uint16(i)
 		w[i].BoolArray[i] = true
+		w[i].Bool2 = true
+		w[i].Packed1 = uint32(i)
+		w[i].Packed2 = int64(i * 2)
+		if i%2 == 0 {
+			w[i].Pointer = new(uint32)
+		}
 	}
 
-	var r [4]s
+	var r [3]skipedStruct
 	b, err := Encode(&w, nil)
 	if err != nil {
 		t.Error(err)
@@ -676,7 +689,7 @@ func TestDecoder(t *testing.T) {
 	if got != -1 {
 		t.Errorf("Decoder: have %d, want %d", got, -1)
 	}
-	n := decoder.skipByType(reflect.TypeOf(uintptr(0)))
+	n := decoder.skipByType(reflect.TypeOf(uintptr(0)), false)
 	if n != -1 {
 		t.Errorf("Decoder: have %d, want %d", n, -1)
 	}

--- a/coder_test.go
+++ b/coder_test.go
@@ -610,6 +610,26 @@ func TestDecoderSkip(t *testing.T) {
 	}
 }
 
+//func TestDecoderSkipError(t *testing.T) {
+//	//	defer func() {
+//	//		if msg := recover(); msg == nil {
+//	//			t.Fatal("did not panic")
+//	//		} else {
+//	//			fmt.Println(msg)
+//	//		}
+//	//	}()
+
+//	bytes := []byte{2, 0, 0, 0, 0}
+//	var dataDecode [0]uintptr
+//	decoder := NewDecoder(bytes)
+//	n := decoder.skipByType(reflect.TypeOf(dataDecode), false)
+//	if n >= 0 {
+//		t.Errorf("DecoderSkipError: have %d, want %d", n, -1)
+//	} else {
+//		//println(n)
+//	}
+//}
+
 func TestFastValue(t *testing.T) {
 	s := _fastValues
 	v := reflect.ValueOf(s)

--- a/decoder.go
+++ b/decoder.go
@@ -91,57 +91,87 @@ func (this *Decoder) Uint8() uint8 {
 
 // Int16 decode an int16 value from Decoder buffer.
 // It will panic if buffer is not enough.
-func (this *Decoder) Int16() int16 {
-	return int16(this.Uint16())
+func (this *Decoder) Int16(packed bool) int16 {
+	if packed {
+		x, _ := this.Varint()
+		return int16(x)
+	} else {
+		return int16(this.Uint16(false))
+	}
 }
 
 // Uint16 decode a uint16 value from Decoder buffer.
 // It will panic if buffer is not enough.
-func (this *Decoder) Uint16() uint16 {
-	b := this.reserve(2)
-	x := this.endian.Uint16(b)
-	return x
+func (this *Decoder) Uint16(packed bool) uint16 {
+	if packed {
+		x, _ := this.Uvarint()
+		return uint16(x)
+	} else {
+		b := this.reserve(2)
+		x := this.endian.Uint16(b)
+		return x
+	}
 }
 
 // Int32 decode an int32 value from Decoder buffer.
 // It will panic if buffer is not enough.
-func (this *Decoder) Int32() int32 {
-	return int32(this.Uint32())
+func (this *Decoder) Int32(packed bool) int32 {
+	if packed {
+		x, _ := this.Varint()
+		return int32(x)
+	} else {
+		return int32(this.Uint32(false))
+	}
 }
 
 // Uint32 decode a uint32 value from Decoder buffer.
 // It will panic if buffer is not enough.
-func (this *Decoder) Uint32() uint32 {
-	b := this.reserve(4)
-	x := this.endian.Uint32(b)
-	return x
+func (this *Decoder) Uint32(packed bool) uint32 {
+	if packed {
+		x, _ := this.Uvarint()
+		return uint32(x)
+	} else {
+		b := this.reserve(4)
+		x := this.endian.Uint32(b)
+		return x
+	}
 }
 
 // Int64 decode an int64 value from Decoder buffer.
 // It will panic if buffer is not enough.
-func (this *Decoder) Int64() int64 {
-	return int64(this.Uint64())
+func (this *Decoder) Int64(packed bool) int64 {
+	if packed {
+		x, _ := this.Varint()
+		return int64(x)
+	} else {
+		return int64(this.Uint64(false))
+	}
 }
 
 // Uint64 decode a uint64 value from Decoder buffer.
 // It will panic if buffer is not enough.
-func (this *Decoder) Uint64() uint64 {
-	b := this.reserve(8)
-	x := this.endian.Uint64(b)
-	return x
+func (this *Decoder) Uint64(packed bool) uint64 {
+	if packed {
+		x, _ := this.Uvarint()
+		return uint64(x)
+	} else {
+		b := this.reserve(8)
+		x := this.endian.Uint64(b)
+		return x
+	}
 }
 
 // Float32 decode a float32 value from Decoder buffer.
 // It will panic if buffer is not enough.
 func (this *Decoder) Float32() float32 {
-	x := math.Float32frombits(this.Uint32())
+	x := math.Float32frombits(this.Uint32(false))
 	return x
 }
 
 // Float64 decode a float64 value from Decoder buffer.
 // It will panic if buffer is not enough.
 func (this *Decoder) Float64() float64 {
-	x := math.Float64frombits(this.Uint64())
+	x := math.Float64frombits(this.Uint64(false))
 	return x
 }
 
@@ -260,13 +290,13 @@ func (this *Decoder) Value(x interface{}) (err error) {
 	}
 
 	if v.Kind() == reflect.Ptr { //only support decode for pointer interface
-		return this.value(v, true)
+		return this.value(v, true, false)
 	} else {
 		return fmt.Errorf("binary.Decoder.Value: non-pointer type %s", v.Type().String())
 	}
 }
 
-func (this *Decoder) value(v reflect.Value, topLevel bool) error {
+func (this *Decoder) value(v reflect.Value, topLevel bool, packed bool) error {
 	// check Packer interface for every value is perfect
 	// but this is too costly
 	//
@@ -308,20 +338,20 @@ func (this *Decoder) value(v reflect.Value, topLevel bool) error {
 	case reflect.Int8:
 		v.SetInt(int64(this.Int8()))
 	case reflect.Int16:
-		v.SetInt(int64(this.Int16()))
+		v.SetInt(int64(this.Int16(packed)))
 	case reflect.Int32:
-		v.SetInt(int64(this.Int32()))
+		v.SetInt(int64(this.Int32(packed)))
 	case reflect.Int64:
-		v.SetInt(this.Int64())
+		v.SetInt(this.Int64(packed))
 
 	case reflect.Uint8:
 		v.SetUint(uint64(this.Uint8()))
 	case reflect.Uint16:
-		v.SetUint(uint64(this.Uint16()))
+		v.SetUint(uint64(this.Uint16(packed)))
 	case reflect.Uint32:
-		v.SetUint(uint64(this.Uint32()))
+		v.SetUint(uint64(this.Uint32(packed)))
 	case reflect.Uint64:
-		v.SetUint(this.Uint64())
+		v.SetUint(this.Uint64(packed))
 
 	case reflect.Float32:
 		v.SetFloat(float64(this.Float32()))
@@ -352,7 +382,7 @@ func (this *Decoder) value(v reflect.Value, topLevel bool) error {
 			l := v.Len()
 			for i := 0; i < size; i++ {
 				if i < l {
-					this.value(v.Index(i), false)
+					this.value(v.Index(i), false, packed)
 				} else {
 					this.skipByType(v.Type().Elem())
 				}
@@ -377,8 +407,8 @@ func (this *Decoder) value(v reflect.Value, topLevel bool) error {
 		for i := 0; i < size; i++ {
 			key := reflect.New(kt).Elem()
 			value := reflect.New(vt).Elem()
-			this.value(key, false)
-			this.value(value, false)
+			this.value(key, false, packed)
+			this.value(value, false, packed)
 			v.SetMapIndex(key, value)
 		}
 	case reflect.Struct:
@@ -387,7 +417,7 @@ func (this *Decoder) value(v reflect.Value, topLevel bool) error {
 	default:
 		if newPtr(v, this, topLevel) {
 			if !v.IsNil() {
-				return this.value(v.Elem(), false)
+				return this.value(v.Elem(), false, packed)
 			}
 		} else {
 			return fmt.Errorf("binary.Decoder.Value: unsupported type %s", v.Type().String())
@@ -411,21 +441,21 @@ func (this *Decoder) fastValue(x interface{}) bool {
 		*d = this.Uint8()
 
 	case *int16:
-		*d = this.Int16()
+		*d = this.Int16(false)
 	case *uint16:
-		*d = this.Uint16()
+		*d = this.Uint16(false)
 
 	case *int32:
-		*d = this.Int32()
+		*d = this.Int32(false)
 	case *uint32:
-		*d = this.Uint32()
+		*d = this.Uint32(false)
 	case *float32:
 		*d = this.Float32()
 
 	case *int64:
-		*d = this.Int64()
+		*d = this.Int64(false)
 	case *uint64:
-		*d = this.Uint64()
+		*d = this.Uint64(false)
 	case *float64:
 		*d = this.Float64()
 	case *complex64:
@@ -486,42 +516,42 @@ func (this *Decoder) fastValue(x interface{}) bool {
 		l := int(s)
 		*d = make([]int16, l)
 		for i := 0; i < l; i++ {
-			(*d)[i] = this.Int16()
+			(*d)[i] = this.Int16(false)
 		}
 	case *[]uint16:
 		s, _ := this.Uvarint()
 		l := int(s)
 		*d = make([]uint16, l)
 		for i := 0; i < l; i++ {
-			(*d)[i] = this.Uint16()
+			(*d)[i] = this.Uint16(false)
 		}
 	case *[]int32:
 		s, _ := this.Uvarint()
 		l := int(s)
 		*d = make([]int32, l)
 		for i := 0; i < l; i++ {
-			(*d)[i] = this.Int32()
+			(*d)[i] = this.Int32(false)
 		}
 	case *[]uint32:
 		s, _ := this.Uvarint()
 		l := int(s)
 		*d = make([]uint32, l)
 		for i := 0; i < l; i++ {
-			(*d)[i] = this.Uint32()
+			(*d)[i] = this.Uint32(false)
 		}
 	case *[]int64:
 		s, _ := this.Uvarint()
 		l := int(s)
 		*d = make([]int64, l)
 		for i := 0; i < l; i++ {
-			(*d)[i] = this.Int64()
+			(*d)[i] = this.Int64(false)
 		}
 	case *[]uint64:
 		s, _ := this.Uvarint()
 		l := int(s)
 		*d = make([]uint64, l)
 		for i := 0; i < l; i++ {
-			(*d)[i] = this.Uint64()
+			(*d)[i] = this.Uint64(false)
 		}
 	case *[]float32:
 		s, _ := this.Uvarint()

--- a/decoder.go
+++ b/decoder.go
@@ -595,19 +595,6 @@ func (this *Decoder) fastValue(x interface{}) bool {
 }
 
 func (this *Decoder) skipByType(t reflect.Type, packed bool) int {
-	//	pos := this.pos
-	//	boolPos := this.boolPos
-	//	boolBit := this.boolBit
-	//	buff := this.buff[this.pos:]
-	//	fmt.Printf("before skip %s\n%d [% x]\n", t.String(), len(buff), buff)
-	//	if l := len(buff); l > 4 {
-	//		buff = buff[:4]
-	//	}
-	//
-	//	defer func() {
-	//		fmt.Printf("after skipByType %s bytes=[% x] pos=%d,%d,%d->%d,%d,%d\n", t.String(), buff, pos, boolPos, boolBit, this.pos, this.boolPos, this.boolBit)
-	//	}()
-
 	if s := fixedTypeSize(t); s > 0 {
 		if packedType := packedIntsType(t); packedType > 0 && packed {
 			switch packedType {

--- a/decoder.go
+++ b/decoder.go
@@ -384,9 +384,8 @@ func (this *Decoder) value(v reflect.Value, topLevel bool, packed bool) error {
 				if i < l {
 					this.value(v.Index(i), false, packed)
 				} else {
-					if elemtype := v.Type().Elem(); this.skipByType(elemtype, packed) < 0 {
-						return fmt.Errorf("binary.Decoder.Value: skip fiail for type %s", elemtype.String())
-					}
+					skiped := this.skipByType(v.Type().Elem(), packed)
+					assert(skiped >= 0, v.Type().Elem().String()) //I'm sure here cannot find unsupported type
 				}
 			}
 		}
@@ -663,7 +662,7 @@ func (this *Decoder) skipByType(t reflect.Type, packed bool) int {
 			sum := sLen //array size
 			for i, n := 0, cnt; i < n; i++ {
 				s := this.skipByType(elemtype, packed)
-				assert(s >= 0, "skip fail"+elemtype.String()) //I'm sure here cannot find unsupported type
+				assert(s >= 0, "skip fail: "+elemtype.String()) //I'm sure here cannot find unsupported type
 				sum += s
 			}
 			return sum

--- a/decoder.go
+++ b/decoder.go
@@ -64,7 +64,6 @@ func (this *Decoder) Init(buffer []byte, endian Endian) {
 func (this *Decoder) Bool() bool {
 	if this.boolBit == 0 {
 		b := this.reserve(1)
-		assert(b != nil, "")
 		this.boolValue = b[0]
 	}
 

--- a/encoder.go
+++ b/encoder.go
@@ -56,7 +56,6 @@ func (this *Encoder) ResizeBuffer(size int) bool {
 func (this *Encoder) Bool(x bool) {
 	if this.boolBit == 0 {
 		b := this.reserve(1)
-		assert(b != nil, "")
 		b[0] = 0
 		this.boolPos = this.pos - 1
 	}

--- a/encoder.go
+++ b/encoder.go
@@ -515,43 +515,6 @@ func (this *Encoder) value(v reflect.Value, packed bool) error {
 	return nil
 }
 
-//func (this *Encoder) nilPointer(t reflect.Type) int {
-//	tt := t
-//	if tt.Kind() == reflect.Ptr {
-//		tt = t.Elem()
-//		if tt.Kind() == reflect.Ptr {
-//			return -1
-//		}
-//	}
-//	if s := fixedTypeSize(tt); s > 0 { //fix size
-//		return this.Skip(s)
-//	}
-//	switch tt.Kind() {
-//	case reflect.Int, reflect.Uint: //zero varint will be encoded as 1 byte
-//		return this.Uvarint(0)
-//	case reflect.Slice, reflect.String:
-//		return this.Uvarint(0)
-//	case reflect.Array:
-//		l := tt.Len()
-//		n := this.Uvarint(uint64(l))
-//		if tt.Elem().Kind() == reflect.Bool { //bool array
-//			n2 := sizeofBoolArray(n)
-//			this.Skip(n2 - n)
-//			n = n2
-//		} else {
-//			tte := tt.Elem()
-//			for i := 0; i < l; i++ {
-//				n += this.nilPointer(tte)
-//			}
-//		}
-//		return n
-
-//	case reflect.Struct:
-//		return queryStruct(tt).encodeNilPointer(this, tt)
-//	}
-//	return -1
-//}
-
 // encode bool array
 func (this *Encoder) boolArray(v reflect.Value) int {
 	if k := v.Kind(); k == reflect.Slice || k == reflect.Array {

--- a/example_test.go
+++ b/example_test.go
@@ -317,10 +317,10 @@ func ExampleRegStruct_packedInts() {
 		fmt.Printf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, size)
 	}
 
-	fmt.Printf("Encode packed ints:\n%#v\nsize=%d result=%#v", ints, len(b), b)
+	fmt.Printf("Encode packed ints:\n%+v\nsize=%d result=%#v", ints, len(b), b)
 
 	// Output:
 	// Encode packed ints:
-	// binary_test.regedPackedInts{A:1, B:2, C:3, D:0x4, E:0x5, F:0x6, G:[]uint64{0x7, 0x8, 0x9}, H:0xa}
+	// {A:1 B:2 C:3 D:4 E:5 F:6 G:[7 8 9] H:10}
 	// size=10 result=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -111,7 +111,7 @@ func ExampleDecode() {
 }
 func ExampleEncoder() {
 	encoder := binary.NewEncoder(100)
-	encoder.Uint32(0x11223344)
+	encoder.Uint32(0x11223344, false)
 	encoder.Varint(-5)
 	encoder.String("hello")
 	encodeResult := encoder.Buffer()
@@ -122,7 +122,7 @@ func ExampleEncoder() {
 func ExampleDecoder() {
 	buffer := []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 	decoder := binary.NewDecoder(buffer)
-	u32 := decoder.Uint32()
+	u32 := decoder.Uint32(false)
 	i, _ := decoder.Varint()
 	str := decoder.String()
 	fmt.Printf("%#v %#v %#v", u32, i, str)
@@ -147,14 +147,14 @@ func (this *S) Encode(buffer []byte) ([]byte, error) {
 	}
 	encoder := binary.NewEncoderBuffer(buff)
 	encoder.Value(this.A)
-	encoder.Int16(int16(this.B))
+	encoder.Int16(int16(this.B), false)
 	encoder.Value(this.C)
 	return encoder.Buffer(), nil
 }
 func (this *S) Decode(buffer []byte) error {
 	decoder := binary.NewDecoder(buffer)
 	decoder.Value(&this.A)
-	this.B = int(decoder.Int16())
+	this.B = int(decoder.Int16(false))
 	decoder.Value(&this.C)
 	return nil
 }

--- a/example_test.go
+++ b/example_test.go
@@ -317,9 +317,10 @@ func ExampleRegStruct_packedInts() {
 		fmt.Printf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, size)
 	}
 
-	fmt.Printf("Encode %+v\nsize=%d result=%#v", ints, len(b), b)
+	fmt.Printf("Encode packed ints:\n%#v\nsize=%d result=%#v", ints, len(b), b)
 
 	// Output:
-	// Encode {A:1 B:2 C:3 D:4 E:5 F:6 G:[7 8 9] H:10}
+	// Encode packed ints:
+	// binary_test.regedPackedInts{A:1, B:2, C:3, D:0x4, E:0x5, F:0x6, G:[]uint64{0x7, 0x8, 0x9}, H:0xa}
 	// size=10 result=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -23,6 +23,7 @@ func ExampleWrite() {
 		fmt.Println("binary.Write failed:", err)
 	}
 	fmt.Printf("%#v", buf.Bytes())
+
 	// Output:
 	// []byte{0x18, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x9, 0x40}
 }
@@ -41,6 +42,7 @@ func ExampleWrite_multi() {
 		}
 	}
 	fmt.Printf("%#v", buf.Bytes())
+
 	// Output:
 	// []byte{0xbe, 0xef, 0xca, 0xfe}
 }
@@ -54,43 +56,48 @@ func ExampleRead() {
 		fmt.Println("binary.Read failed:", err)
 	}
 	fmt.Print(pi)
+
 	// Output:
 	// 3.141592653589793
 }
 
 func ExampleEncode() {
-	var s struct {
+	var data struct {
 		A uint32
 		B int
 		C string
 	}
-	s.A = 0x11223344
-	s.B = -5
-	s.C = "hello"
-	b, err := binary.Encode(s, nil)
+	data.A = 0x11223344
+	data.B = -5
+	data.C = "hello"
+
+	b, err := binary.Encode(data, nil)
 	if err != nil {
 		fmt.Println("binary.Encode failed:", err)
 	}
 	fmt.Printf("%#v", b)
+
 	// Output:
 	// []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 }
 func ExampleEncode_withbuffer() {
-	var s struct {
+	var data struct {
 		A uint32
 		B int
 		C string
 	}
-	s.A = 0x11223344
-	s.B = -5
-	s.C = "hello"
-	size := binary.Sizeof(s)
+	data.A = 0x11223344
+	data.B = -5
+	data.C = "hello"
+	size := binary.Sizeof(data)
 	buffer := make([]byte, size)
-	b, err := binary.Encode(s, buffer)
+
+	b, err := binary.Encode(data, buffer)
 	if err != nil {
 		fmt.Println("binary.Encode failed:", err)
 	}
 	fmt.Printf("%#v", b)
+
 	// Output:
 	// []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 }
@@ -105,18 +112,19 @@ func ExampleEncode_bools() {
 		G bool    //true
 		H uint8   //0x33
 	}
-	var bools = boolset{
+	var data = boolset{
 		0x11, true, 0x22, []bool{true, false, true}, true, nil, true, 0x33,
 	}
-	b, err := binary.Encode(bools, nil)
+	b, err := binary.Encode(data, nil)
 	if err != nil {
 		fmt.Println(err)
 	}
-	size := binary.Sizeof(bools)
-	if size != len(b) {
+
+	if size := binary.Sizeof(data); size != len(b) {
 		fmt.Printf("Encode got %#v %+v\nneed %+v\n", len(b), b, size)
 	}
-	fmt.Printf("Encode %#v\nsize=%d result=%#v", bools, len(b), b)
+	fmt.Printf("Encode %#v\nsize=%d result=%#v", data, len(b), b)
+
 	// Output:
 	// Encode binary_test.boolset{A:0x11, B:true, C:0x22, D:[]bool{true, false, true}, E:true, F:(*uint32)(nil), G:true, H:0x33}
 	// size=6 result=[]byte{0x11, 0xb, 0x22, 0x3, 0x5, 0x33}
@@ -139,21 +147,25 @@ func ExampleDecode() {
 }
 func ExampleEncoder() {
 	encoder := binary.NewEncoder(100)
+
 	encoder.Uint32(0x11223344, false)
 	encoder.Varint(-5)
 	encoder.String("hello")
 	encodeResult := encoder.Buffer()
 	fmt.Printf("%#v", encodeResult)
+
 	// Output:
 	// []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 }
 func ExampleDecoder() {
 	buffer := []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
+
 	decoder := binary.NewDecoder(buffer)
 	u32 := decoder.Uint32(false)
 	i, _ := decoder.Varint()
 	str := decoder.String()
 	fmt.Printf("%#v %#v %#v", u32, i, str)
+
 	// Output:
 	// 0x11223344 -5 "hello"
 }
@@ -200,14 +212,14 @@ func ExampleBinarySerializer() {
 		func (this *S) Encode() ([]byte, error) {
 			encoder := binary.NewEncoder(this.Size())
 			encoder.Value(this.A)
-			encoder.Int16(int16(this.B))
+			encoder.Int16(int16(this.B), false)
 			encoder.Value(this.C)
 			return encoder.Buffer(), nil
 		}
 		func (this *S) Decode(buffer []byte) error {
 			decoder := binary.NewDecoder(buffer)
 			decoder.Value(&this.A)
-			this.B = int(decoder.Int16())
+			this.B = int(decoder.Int16(false))
 			decoder.Value(&this.C)
 			return nil
 		}
@@ -216,20 +228,22 @@ func ExampleBinarySerializer() {
 	s.A = 0x11223344
 	s.B = -5
 	s.C = "hello"
-	b, err := binary.Encode(&s, nil)
 
+	b, err := binary.Encode(&s, nil)
 	if err != nil {
 		fmt.Println("binary.Encode failed:", err)
 	}
+
 	err = binary.Decode(b, &ss)
 	if err != nil {
 		fmt.Println("binary.Decode failed:", err)
 	}
-	fmt.Printf("[%+v\n%#v\n%+v]", s, b, ss)
+	fmt.Printf("%+v\n%#v\n%+v", s, b, ss)
+
 	// Output:
-	// [{A:287454020 B:-5 C:hello}
+	// {A:287454020 B:-5 C:hello}
 	// []byte{0x44, 0x33, 0x22, 0x11, 0xfb, 0xff, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
-	// {A:287454020 B:-5 C:hello}]
+	// {A:287454020 B:-5 C:hello}
 }
 
 func ExampleSizeof() {
@@ -261,6 +275,7 @@ func ExampleSizeof() {
 	size := binary.Sizeof(s)
 
 	fmt.Printf("Sizeof(s)  = %d\nstd.Size(s)= %d\ngob.Size(s)= %d", size, stdSize, gobSize)
+
 	// Output:
 	// Sizeof(s)  = 133
 	// std.Size(s)= 217
@@ -275,6 +290,7 @@ func ExampleRegStruct() {
 		D uint
 	}
 	binary.RegStruct((*someRegedStruct)(nil))
+
 	// Output:
 }
 
@@ -300,9 +316,10 @@ func ExampleRegStruct_packedInts() {
 	if size := binary.Sizeof(ints); size != len(b) {
 		fmt.Printf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, size)
 	}
-	fmt.Printf("Encode %+v\nsize=%d reault=%#v\n", ints, len(b), b)
+
+	fmt.Printf("Encode %+v\nsize=%d result=%#v", ints, len(b), b)
 
 	// Output:
 	// Encode {A:1 B:2 C:3 D:4 E:5 F:6 G:[7 8 9] H:10}
-	// size=10 reault=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
+	// size=10 result=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -94,6 +94,34 @@ func ExampleEncode_withbuffer() {
 	// Output:
 	// []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 }
+func ExampleEncode_bools() {
+	type boolset struct {
+		A uint8   //0x11
+		B bool    //true
+		C uint8   //0x22
+		D []bool  //[]bool{true, false, true}
+		E bool    //true
+		F *uint32 //false
+		G bool    //true
+		H uint8   //0x33
+	}
+	var bools = boolset{
+		0x11, true, 0x22, []bool{true, false, true}, true, nil, true, 0x33,
+	}
+	b, err := binary.Encode(bools, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+	size := binary.Sizeof(bools)
+	if size != len(b) {
+		fmt.Printf("Encode got %#v %+v\nneed %+v\n", len(b), b, size)
+	}
+	fmt.Printf("Encode %#v\nsize=%d result=%#v", bools, len(b), b)
+	// Output:
+	// Encode binary_test.boolset{A:0x11, B:true, C:0x22, D:[]bool{true, false, true}, E:true, F:(*uint32)(nil), G:true, H:0x33}
+	// size=6 result=[]byte{0x11, 0xb, 0x22, 0x3, 0x5, 0x33}
+}
+
 func ExampleDecode() {
 	var s struct {
 		A uint32
@@ -241,10 +269,39 @@ func ExampleSizeof() {
 
 func ExampleRegStruct() {
 	type someRegedStruct struct {
-		A int `binary:"ignore"`
-		B string
-		C uint
+		A int    `binary:"ignore"`
+		B uint64 `binary:"packed"`
+		C string
+		D uint
 	}
 	binary.RegStruct((*someRegedStruct)(nil))
 	// Output:
+}
+
+func ExampleRegStruct_PackedInts() {
+	type regedPackedInts struct {
+		A int16    `binary:"packed"`
+		B int32    `binary:"packed"`
+		C int64    `binary:"packed"`
+		D uint16   `binary:"packed"`
+		E uint32   `binary:"packed"`
+		F uint64   `binary:"packed"`
+		G []uint64 `binary:"packed"`
+		H uint     `binary:"ignore"`
+	}
+	binary.RegStruct((*regedPackedInts)(nil))
+
+	var ints = regedPackedInts{1, 2, 3, 4, 5, 6, []uint64{7, 8, 9}, 10}
+	b, err := binary.Encode(ints, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+	size := binary.Sizeof(ints)
+	if size != len(b) {
+		fmt.Printf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, size)
+	}
+	fmt.Printf("Encode %+v\nsize=%d reault=%#v", ints, len(b), b)
+	// Output:
+	// Encode {A:1 B:2 C:3 D:4 E:5 F:6 G:[7 8 9] H:10}
+	// size=10 reault=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -75,9 +75,11 @@ func ExampleEncode() {
 	if err != nil {
 		fmt.Println("binary.Encode failed:", err)
 	}
-	fmt.Printf("%#v", b)
+	fmt.Printf("Encode:\n%+v\n%#v", data, b)
 
 	// Output:
+	// Encode:
+	// {A:287454020 B:-5 C:hello}
 	// []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 }
 func ExampleEncode_withbuffer() {
@@ -96,24 +98,26 @@ func ExampleEncode_withbuffer() {
 	if err != nil {
 		fmt.Println("binary.Encode failed:", err)
 	}
-	fmt.Printf("%#v", b)
+	fmt.Printf("Encode:\n%+v\n%#v", data, b)
 
 	// Output:
+	// Encode:
+	// {A:287454020 B:-5 C:hello}
 	// []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 }
 func ExampleEncode_bools() {
 	type boolset struct {
-		A uint8   //0x11
+		A uint8   //0xa
 		B bool    //true
-		C uint8   //0x22
+		C uint8   //0xc
 		D []bool  //[]bool{true, false, true}
 		E bool    //true
 		F *uint32 //false
 		G bool    //true
-		H uint8   //0x33
+		H uint8   //0x8
 	}
 	var data = boolset{
-		0x11, true, 0x22, []bool{true, false, true}, true, nil, true, 0x33,
+		0xa, true, 0xc, []bool{true, false, true}, true, nil, true, 0x8,
 	}
 	b, err := binary.Encode(data, nil)
 	if err != nil {
@@ -123,12 +127,12 @@ func ExampleEncode_bools() {
 	if size := binary.Sizeof(data); size != len(b) {
 		fmt.Printf("Encode got %#v %+v\nneed %+v\n", len(b), b, size)
 	}
-	fmt.Printf("Encode bools:\n%#v\nsize=%d result=%#v", data, len(b), b)
+	fmt.Printf("Encode bools:\n%+v\nsize=%d result=%#v", data, len(b), b)
 
 	// Output:
 	// Encode bools:
-	// binary_test.boolset{A:0x11, B:true, C:0x22, D:[]bool{true, false, true}, E:true, F:(*uint32)(nil), G:true, H:0x33}
-	// size=6 result=[]byte{0x11, 0xb, 0x22, 0x3, 0x5, 0x33}
+	// {A:10 B:true C:12 D:[true false true] E:true F:<nil> G:true H:8}
+	// size=6 result=[]byte{0xa, 0xb, 0xc, 0x3, 0x5, 0x8}
 }
 
 func ExampleEncode_boolArray() {
@@ -187,11 +191,13 @@ func ExampleDecode() {
 		C string
 	}
 	buffer := []byte{0x44, 0x33, 0x22, 0x11, 0x9, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
+
 	err := binary.Decode(buffer, &s)
 	if err != nil {
 		fmt.Println("binary.Decode failed:", err)
 	}
 	fmt.Printf("%+v", s)
+
 	// Output:
 	// {A:287454020 B:-5 C:hello}
 }
@@ -274,21 +280,21 @@ func ExampleBinarySerializer() {
 			return nil
 		}
 	*/
-	var s, ss S
-	s.A = 0x11223344
-	s.B = -5
-	s.C = "hello"
+	var data, dataDecode S
+	data.A = 0x11223344
+	data.B = -5
+	data.C = "hello"
 
-	b, err := binary.Encode(&s, nil)
+	b, err := binary.Encode(&data, nil)
 	if err != nil {
 		fmt.Println("binary.Encode failed:", err)
 	}
 
-	err = binary.Decode(b, &ss)
+	err = binary.Decode(b, &dataDecode)
 	if err != nil {
 		fmt.Println("binary.Decode failed:", err)
 	}
-	fmt.Printf("%+v\n%#v\n%+v", s, b, ss)
+	fmt.Printf("%+v\n%#v\n%+v", data, b, dataDecode)
 
 	// Output:
 	// {A:287454020 B:-5 C:hello}
@@ -324,12 +330,12 @@ func ExampleSizeof() {
 	stdSize := std.Size(s)
 	size := binary.Sizeof(s)
 
-	fmt.Printf("Sizeof(s)  = %d\nstd.Size(s)= %d\ngob.Size(s)= %d", size, stdSize, gobSize)
+	fmt.Printf("Sizeof(s)  = %d\nstd Size(s)= %d\ngob Size(s)= %d", size, stdSize, gobSize)
 
 	// Output:
 	// Sizeof(s)  = 133
-	// std.Size(s)= 217
-	// gob.Size(s)= 412
+	// std Size(s)= 217
+	// gob Size(s)= 412
 }
 
 func ExampleRegStruct() {
@@ -341,5 +347,20 @@ func ExampleRegStruct() {
 	}
 	binary.RegStruct((*someRegedStruct)(nil))
 
+	var data = someRegedStruct{1, 2, "hello", 3}
+	b, err := binary.Encode(data, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if size := binary.Sizeof(data); size != len(b) {
+		fmt.Printf("RegedStruct got %+v %+v\nneed %+v\n", len(b), b, size)
+	}
+
+	fmt.Printf("Encode reged struct:\n%+v\nsize=%d result=%#v", data, len(b), b)
+
 	// Output:
+	// Encode reged struct:
+	// {A:1 B:2 C:hello D:3}
+	// size=8 result=[]byte{0x2, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x3}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -123,11 +123,30 @@ func ExampleEncode_bools() {
 	if size := binary.Sizeof(data); size != len(b) {
 		fmt.Printf("Encode got %#v %+v\nneed %+v\n", len(b), b, size)
 	}
-	fmt.Printf("Encode %#v\nsize=%d result=%#v", data, len(b), b)
+	fmt.Printf("Encode bools:\n%#v\nsize=%d result=%#v", data, len(b), b)
 
 	// Output:
-	// Encode binary_test.boolset{A:0x11, B:true, C:0x22, D:[]bool{true, false, true}, E:true, F:(*uint32)(nil), G:true, H:0x33}
+	// Encode bools:
+	// binary_test.boolset{A:0x11, B:true, C:0x22, D:[]bool{true, false, true}, E:true, F:(*uint32)(nil), G:true, H:0x33}
 	// size=6 result=[]byte{0x11, 0xb, 0x22, 0x3, 0x5, 0x33}
+}
+
+func ExampleEncode_boolArray() {
+	var data = []bool{true, true, true, false, true, true, false, false, true}
+	b, err := binary.Encode(data, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if size := binary.Sizeof(data); size != len(b) {
+		fmt.Printf("Encode bool array:\ngot %#v %+v\nneed %+v\n", len(b), b, size)
+	}
+	fmt.Printf("Encode bool array:\n%#v\nsize=%d result=%#v", data, len(b), b)
+
+	// Output:
+	// Encode bool array:
+	// []bool{true, true, true, false, true, true, false, false, true}
+	// size=3 result=[]byte{0x9, 0x37, 0x1}
 }
 
 func ExampleDecode() {

--- a/example_test.go
+++ b/example_test.go
@@ -278,7 +278,7 @@ func ExampleRegStruct() {
 	// Output:
 }
 
-func ExampleRegStruct_PackedInts() {
+func ExampleRegStruct_packedInts() {
 	type regedPackedInts struct {
 		A int16    `binary:"packed"`
 		B int32    `binary:"packed"`
@@ -296,11 +296,12 @@ func ExampleRegStruct_PackedInts() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	size := binary.Sizeof(ints)
-	if size != len(b) {
+
+	if size := binary.Sizeof(ints); size != len(b) {
 		fmt.Printf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, size)
 	}
-	fmt.Printf("Encode %+v\nsize=%d reault=%#v", ints, len(b), b)
+	fmt.Printf("Encode %+v\nsize=%d reault=%#v\n", ints, len(b), b)
+
 	// Output:
 	// Encode {A:1 B:2 C:3 D:4 E:5 F:6 G:[7 8 9] H:10}
 	// size=10 reault=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}

--- a/example_test.go
+++ b/example_test.go
@@ -149,6 +149,37 @@ func ExampleEncode_boolArray() {
 	// size=3 result=[]byte{0x9, 0x37, 0x1}
 }
 
+func ExampleEncode_packedInts() {
+	type regedPackedInts struct {
+		A int16    `binary:"packed"`
+		B int32    `binary:"packed"`
+		C int64    `binary:"packed"`
+		D uint16   `binary:"packed"`
+		E uint32   `binary:"packed"`
+		F uint64   `binary:"packed"`
+		G []uint64 `binary:"packed"`
+		H uint     `binary:"ignore"`
+	}
+	binary.RegStruct((*regedPackedInts)(nil))
+
+	var data = regedPackedInts{1, 2, 3, 4, 5, 6, []uint64{7, 8, 9}, 10}
+	b, err := binary.Encode(data, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if size := binary.Sizeof(data); size != len(b) {
+		fmt.Printf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, size)
+	}
+
+	fmt.Printf("Encode packed ints:\n%+v\nsize=%d result=%#v", data, len(b), b)
+
+	// Output:
+	// Encode packed ints:
+	// {A:1 B:2 C:3 D:4 E:5 F:6 G:[7 8 9] H:10}
+	// size=10 result=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
+}
+
 func ExampleDecode() {
 	var s struct {
 		A uint32
@@ -311,35 +342,4 @@ func ExampleRegStruct() {
 	binary.RegStruct((*someRegedStruct)(nil))
 
 	// Output:
-}
-
-func ExampleRegStruct_packedInts() {
-	type regedPackedInts struct {
-		A int16    `binary:"packed"`
-		B int32    `binary:"packed"`
-		C int64    `binary:"packed"`
-		D uint16   `binary:"packed"`
-		E uint32   `binary:"packed"`
-		F uint64   `binary:"packed"`
-		G []uint64 `binary:"packed"`
-		H uint     `binary:"ignore"`
-	}
-	binary.RegStruct((*regedPackedInts)(nil))
-
-	var ints = regedPackedInts{1, 2, 3, 4, 5, 6, []uint64{7, 8, 9}, 10}
-	b, err := binary.Encode(ints, nil)
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	if size := binary.Sizeof(ints); size != len(b) {
-		fmt.Printf("PackedInts got %+v %+v\nneed %+v\n", len(b), b, size)
-	}
-
-	fmt.Printf("Encode packed ints:\n%+v\nsize=%d result=%#v", ints, len(b), b)
-
-	// Output:
-	// Encode packed ints:
-	// {A:1 B:2 C:3 D:4 E:5 F:6 G:[7 8 9] H:10}
-	// size=10 result=[]byte{0x2, 0x4, 0x6, 0x4, 0x5, 0x6, 0x3, 0x7, 0x8, 0x9}
 }

--- a/func.go
+++ b/func.go
@@ -317,14 +317,14 @@ func sizeofNilPointer(t reflect.Type) int {
 			return SizeofUvarint(0)
 		}
 	case reflect.Array:
-		elem := tt.Elem()
-		if s := fixedTypeSize(elem); s > 0 {
-			if elem.Kind() == reflect.Bool {
-				return sizeofBoolArray(tt.Len())
-			}
+		elemtype := tt.Elem()
+		if s := fixedTypeSize(elemtype); s > 0 {
 			return sizeofFixArray(tt.Len(), s)
 		} else {
-			size := sizeofNilPointer(elem)
+			if elemtype.Kind() == reflect.Bool {
+				return sizeofBoolArray(tt.Len())
+			}
+			size := sizeofNilPointer(elemtype)
 			if size > 0 { //verify element type valid
 				return sizeofFixArray(tt.Len(), size)
 			}

--- a/func.go
+++ b/func.go
@@ -202,7 +202,10 @@ func bitsOfUnfixedArray(v reflect.Value, packed bool) int {
 }
 
 // sizeof returns the size >= 0 of variables for the given type or -1 if the type is not acceptable.
-func bitsOfValue(v reflect.Value, topLevel bool, packed bool) int {
+func bitsOfValue(v reflect.Value, topLevel bool, packed bool) (r int) {
+	//	defer func() {
+	//		fmt.Printf("bitsOfValue(%#v)=%d\n", v.Interface(), r)
+	//	}()
 	bits := 0
 	if v.Kind() == reflect.Ptr { //nil is not aviable
 		if !topLevel {
@@ -219,7 +222,9 @@ func bitsOfValue(v reflect.Value, topLevel bool, packed bool) int {
 	v = reflect.Indirect(v) //redrect pointer to it's value
 	t := v.Type()
 	if s := fixedTypeSize(t); s > 0 { //fixed size
-		if packedType := packedIntsType(t); packedType > 0 && packed {
+		if t.Kind() == reflect.Bool {
+			return 1 + bits
+		} else if packedType := packedIntsType(t); packedType > 0 && packed {
 			switch packedType {
 			case _SignedInts:
 				return SizeofVarint(v.Int())*8 + bits

--- a/struct.go
+++ b/struct.go
@@ -90,18 +90,6 @@ func (this *structInfo) encode(encoder *Encoder, v reflect.Value) error {
 	return nil
 }
 
-//func (this *structInfo) encodeNilPointer(encoder *Encoder, t reflect.Type) int {
-//	sum := 0
-//	for i, n := 0, this.fieldNum(t); i < n; i++ {
-//		s := encoder.nilPointer(this.fieldType(i, t))
-//		if s < 0 {
-//			return -1
-//		}
-//		sum += s
-//	}
-//	return sum
-//}
-
 func (this *structInfo) decode(decoder *Decoder, v reflect.Value) error {
 	t := v.Type()
 	//assert(t.Kind() == reflect.Struct, t.String())
@@ -166,15 +154,6 @@ func (this *structInfo) sizeofNilPointer(t reflect.Type) int {
 func (this *structInfo) fieldValid(i int, t reflect.Type) bool {
 	return this.field(i).valid(i, t)
 }
-
-//func (this *structInfo) fieldType(i int, t reflect.Type) reflect.Type {
-//	if this == nil {
-//		return t.Field(i).Type
-
-//	} else {
-//		return this.field(i).field.Type
-//	}
-//}
 
 func (this *structInfo) fieldNum(t reflect.Type) int {
 	if this == nil {

--- a/struct.go
+++ b/struct.go
@@ -118,13 +118,14 @@ func (this *structInfo) decode(decoder *Decoder, v reflect.Value) error {
 	return nil
 }
 
-func (this *structInfo) decodeSkipByType(decoder *Decoder, t reflect.Type) int {
+func (this *structInfo) decodeSkipByType(decoder *Decoder, t reflect.Type, packed bool) int {
 	//assert(t.Kind() == reflect.Struct, t.String())
 	sum := 0
 	for i, n := 0, t.NumField(); i < n; i++ {
-		ft := this.field(i).Type(i, t)
-		s := decoder.skipByType(ft)
-		assert(s >= 0, "") //I'm sure here cannot find unsupported type
+		f := this.field(i)
+		ft := f.Type(i, t)
+		s := decoder.skipByType(ft, f.packed())
+		assert(s >= 0, "skip struct field fail:"+ft.String()) //I'm sure here cannot find unsupported type
 		sum += s
 	}
 	return sum


### PR DESCRIPTION
use field tag `binary:"packed"` to encode ints value as varint/uvarint for reged structs